### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/backend/functions/services/fileService.js
+++ b/backend/functions/services/fileService.js
@@ -618,7 +618,7 @@ const deleteFromTelegram = async (fileId, userId) => {
     await telegramBot.deleteMessage(chatId, messageId);
   } catch (error) {
     if (error.response && error.response.body && error.response.body.description.includes("message can't be deleted for everyone")) {
-      console.warn(`Message for file ID ${fileId} cannot be deleted for everyone on Telegram:`, error.response.body.description);
+      console.warn('Message for file ID %s cannot be deleted for everyone on Telegram:', fileId, error.response.body.description);
       // Log this as a non-critical issue and proceed with deleting from the database
     } else {
       // If the error is something else, rethrow it to be handled by the calling function


### PR DESCRIPTION
Potential fix for [https://github.com/jainyash0007/storagegram/security/code-scanning/3](https://github.com/jainyash0007/storagegram/security/code-scanning/3)

Use a constant format string and pass untrusted values as separate arguments (`%s` placeholders), rather than embedding them into the first argument via template literals.

Best fix in `backend/functions/services/fileService.js`:
- Update the `console.warn` at line 621 inside `deleteFromTelegram`.
- Replace the template literal first argument with a static format string like:
  - `"Message for file ID %s cannot be deleted for everyone on Telegram:"`
- Pass `fileId` as a subsequent argument, followed by `error.response.body.description`.

This preserves existing behavior and message content while removing attacker control over the format string itself. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
