### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/backend/functions/services/fileService.js
+++ b/backend/functions/services/fileService.js
@@ -372,7 +372,7 @@ const deleteFile = async (req) => {
       if (platform === 'telegram' && error.response && error.response.body && 
         (error.response.body.description.includes('message to delete not found') || 
          error.response.body.description.includes("message can't be deleted for everyone"))) {
-      console.warn(`Message for file ID ${id} cannot be deleted on Telegram:`, error.response.body.description);
+      console.warn('Message for file ID %s cannot be deleted on Telegram:', id, error.response.body.description);
     } else {
       throw error;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/jainyash0007/storagegram/security/code-scanning/2](https://github.com/jainyash0007/storagegram/security/code-scanning/2)

Use a constant format string as the first argument to `console.warn`, and pass untrusted values (`id`) as separate arguments bound to `%s`. This preserves current behavior while removing attacker control over formatting directives.

Best single fix in `backend/functions/services/fileService.js`:
- Edit the `console.warn` call in the Telegram deletion warning branch (around line 375).
- Replace template-literal interpolation in argument 1 with a static format string:  
  `console.warn('Message for file ID %s cannot be deleted on Telegram:', id, error.response.body.description);`
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
