### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/backend/functions/services/fileService.js
+++ b/backend/functions/services/fileService.js
@@ -286,7 +286,7 @@ const downloadFile = async (req, res) => {
     });
 
   } catch (error) {
-    console.error(`Error in downloadFile for fileId ${fileId}:`, error);
+    console.error('Error in downloadFile for fileId %s:', fileId, error);
     throw new Error('Failed to download file');
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/jainyash0007/storagegram/security/code-scanning/1](https://github.com/jainyash0007/storagegram/security/code-scanning/1)

The safest fix is to ensure untrusted data is **not used as the format string**. Keep a static format string and pass untrusted values as separate `%s` arguments.

Best targeted change in `backend/functions/services/fileService.js`:
- Update the `console.error` in `downloadFile`’s `catch` block (line 289 area).
- Replace template-literal interpolation in argument 1 with a literal format string like:
  - `console.error('Error in downloadFile for fileId %s:', fileId, error);`

This preserves functionality and log content while preventing user input from controlling format specifiers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
